### PR TITLE
feat: [PIDM-2152] add npg sdk sync pipeline

### DIFF
--- a/.devops/azure-templates/sync-npg-sdk-steps.yml
+++ b/.devops/azure-templates/sync-npg-sdk-steps.yml
@@ -1,10 +1,9 @@
-# Reusable steps to sync one NPG SDK variant to the platform CDN.
-# Downloads the SDK from an NPG origin, computes its SHA-384, verifies it against
-# NPG's source-of-truth hash (fetched from the payment-methods-handler integrity
-# endpoint via APIM), and only on a match publishes hfsdk.js + hfsdk.integrity.json
-# into the given folder of the platform CDN ($web). On a mismatch it fails and the
-# last-known-good stays served. The storage key is read from the AZURE_STORAGE_KEY
-# env var (set by the caller from a secret pipeline variable), never a parameter.
+# Reusable steps to sync one NPG SDK variant to the platform CDN ($web).
+# Downloads the SDK, computes its SHA-384, verifies it against NPG's source-of-truth
+# hash (payment-methods-handler /integrity via APIM), and only on a match publishes
+# hfsdk.js + hfsdk.integrity.json into target_folder. On a mismatch it fails and the
+# last-known-good stays served. The storage key comes from the AZURE_STORAGE_KEY env
+# var (a secret pipeline variable), never a parameter.
 parameters:
   - name: npg_origin
     type: string
@@ -48,8 +47,7 @@ steps:
 
         TARGET_FOLDER="${{ parameters.target_folder }}"
         STORAGE_ACCOUNT="${{ parameters.storage_account }}"
-        # the injected endpoint-name variable can carry stray whitespace; strip it
-        # so the AFD purge targets the real endpoint.
+        # strip stray whitespace from the injected endpoint name so the purge hits it
         CDN_ENDPOINT="$(printf '%s' "${{ parameters.cdn_endpoint }}" | tr -d '[:space:]')"
         EMIT_HEARTBEAT="${{ parameters.emit_heartbeat }}"
 
@@ -69,10 +67,9 @@ steps:
         INTEGRITY="sha384-${HASH}"
         echo "Computed integrity: ${INTEGRITY}"
 
-        # Origin validation: compare the computed hash against NPG's own published hash,
-        # fetched from the payment-methods-handler integrity endpoint (exposed on APIM in
-        # the ecommerce-for-checkout group). The pipeline holds no NPG credential; the
-        # handler owns the npg-api-key and proxies NPG /build/integrity.
+        # Origin validation: compare the computed hash against NPG's own published hash
+        # from the handler /integrity (via APIM). The handler owns the npg-api-key and
+        # proxies NPG /build/integrity; the pipeline holds no NPG credential.
         echo "Fetching source-of-truth integrity from ${{ parameters.integrity_endpoint }}"
         SOT_CODE=$(curl -sSL -w "%{http_code}" -o /tmp/sot.json "${{ parameters.integrity_endpoint }}")
         if [ "${SOT_CODE}" != "200" ]; then
@@ -127,13 +124,11 @@ steps:
           --profile-name "${{ parameters.cdn_profile }}" \
           --content-paths "/${TARGET_FOLDER}/*"
 
-        # Success heartbeat: emit a NpgSdkSyncSuccess customEvent to App Insights, only
-        # for the variant that backs prod consumption (the paging source for the
-        # staleness alert). No heartbeat in the last 3h => the sync has stopped/failing.
+        # Success heartbeat: NpgSdkSyncSuccess customEvent to App Insights, prod variant
+        # only (paging source for the staleness alert; no heartbeat in 3h => stale).
         if [ "${EMIT_HEARTBEAT}" = "true" ]; then
           echo "Emitting sync-success heartbeat to App Insights"
-          # disable xtrace so the App Insights connection string / instrumentation
-          # key are never echoed to the log
+          # disable xtrace so the connection string / iKey are never logged
           set +x
           # bounded with timeout so a hung ARM call can never stall the pipeline
           AI_CONN=$(timeout 30 az monitor app-insights component show \
@@ -144,21 +139,18 @@ steps:
             IKEY=$(printf '%s' "${AI_CONN}" | sed -n 's/.*InstrumentationKey=\([^;]*\).*/\1/p')
             INGEST=$(printf '%s' "${AI_CONN}" | sed -n 's/.*IngestionEndpoint=\([^;]*\).*/\1/p')
             HEARTBEAT_TIME=$(date -u +%Y-%m-%dT%H:%M:%S.000Z)
-            # payload + response go to unpredictable temp files (mktemp). Keeping the
-            # iKey in the payload file means it never lands in the process args (argv).
+            # temp files (mktemp) keep the iKey out of the process args (argv)
             HB_PAYLOAD=$(mktemp)
             HB_RESP=$(mktemp)
             printf '{"name":"Microsoft.ApplicationInsights.Event","time":"%s","iKey":"%s","data":{"baseType":"EventData","baseData":{"ver":2,"name":"NpgSdkSyncSuccess","properties":{"integrity":"%s","folder":"%s"}}}}' \
               "${HEARTBEAT_TIME}" "${IKEY}" "${INTEGRITY}" "${TARGET_FOLDER}" > "${HB_PAYLOAD}"
-            # -o sends the body to a file (never stdout); -w prints only the HTTP
-            # status; connect/max timeouts guarantee the call cannot hang the job.
+            # -o body to file, -w prints only HTTP status; timeouts prevent a hang
             HB_CODE=$(curl -sS -o "${HB_RESP}" -w '%{http_code}' \
               --connect-timeout 10 --max-time 30 \
               -X POST "${INGEST}v2/track" -H 'Content-Type: application/json' \
               -d @"${HB_PAYLOAD}" || true)
-            # itemsAccepted is the authoritative "did it land" signal - a 200 alone is
-            # not enough (App Insights can 200 with itemsAccepted:0). The v2/track
-            # response never contains the iKey, so these fields are safe to log.
+            # itemsAccepted is authoritative: App Insights can 200 with itemsAccepted:0.
+            # The v2/track response has no iKey, so these fields are safe to log.
             HB_ACCEPTED=$(sed -n 's/.*"itemsAccepted":\([0-9][0-9]*\).*/\1/p' "${HB_RESP}")
             HB_ERRORS=$(sed -n 's/.*\("errors":\[[^]]*\]\).*/\1/p' "${HB_RESP}")
             rm -f "${HB_PAYLOAD}" "${HB_RESP}"

--- a/.devops/azure-templates/sync-npg-sdk-steps.yml
+++ b/.devops/azure-templates/sync-npg-sdk-steps.yml
@@ -1,0 +1,175 @@
+# Reusable steps to sync one NPG SDK variant to the platform CDN.
+# Downloads the SDK from an NPG origin, computes its SHA-384, verifies it against
+# NPG's source-of-truth hash (fetched from the payment-methods-handler integrity
+# endpoint via APIM), and only on a match publishes hfsdk.js + hfsdk.integrity.json
+# into the given folder of the platform CDN ($web). On a mismatch it fails and the
+# last-known-good stays served. The storage key is read from the AZURE_STORAGE_KEY
+# env var (set by the caller from a secret pipeline variable), never a parameter.
+parameters:
+  - name: npg_origin
+    type: string
+  - name: integrity_endpoint
+    type: string
+  - name: target_folder            # e.g. npg-uat or npg-prod
+    type: string
+  - name: storage_account
+    type: string
+  - name: cdn_rg
+    type: string
+  - name: cdn_profile
+    type: string
+  - name: cdn_endpoint
+    type: string
+  - name: service_connection
+    type: string
+  - name: emit_heartbeat           # 'true' only for the prod variant (paging source)
+    type: string
+    default: 'false'
+  - name: app_insights_name
+    type: string
+    default: ''
+  - name: app_insights_rg
+    type: string
+    default: ''
+
+steps:
+  - checkout: none
+
+  - task: AzureCLI@2
+    displayName: 'Sync NPG SDK -> ${{ parameters.target_folder }}'
+    env:
+      AZURE_STORAGE_KEY: $(PROD_AZURE_STORAGE_KEY)
+    inputs:
+      azureSubscription: '${{ parameters.service_connection }}'
+      scriptType: bash
+      scriptLocation: inlineScript
+      inlineScript: |
+        set -euo pipefail
+
+        TARGET_FOLDER="${{ parameters.target_folder }}"
+        STORAGE_ACCOUNT="${{ parameters.storage_account }}"
+        # the injected endpoint-name variable can carry stray whitespace; strip it
+        # so the AFD purge targets the real endpoint.
+        CDN_ENDPOINT="$(printf '%s' "${{ parameters.cdn_endpoint }}" | tr -d '[:space:]')"
+        EMIT_HEARTBEAT="${{ parameters.emit_heartbeat }}"
+
+        SDK_URL="${{ parameters.npg_origin }}/monetaweb/resources/hfsdk.js"
+        echo "Downloading SDK from ${SDK_URL}"
+
+        HTTP_CODE=$(curl -sSL -w "%{http_code}" -o /tmp/hfsdk.js "${SDK_URL}")
+        if [ "${HTTP_CODE}" != "200" ]; then
+          echo "##vso[task.logissue type=error]SDK download failed with HTTP ${HTTP_CODE}"
+          exit 1
+        fi
+
+        FILE_SIZE=$(stat -c%s /tmp/hfsdk.js)
+        echo "SDK downloaded: ${FILE_SIZE} bytes"
+
+        HASH=$(openssl dgst -sha384 -binary /tmp/hfsdk.js | openssl base64 -A)
+        INTEGRITY="sha384-${HASH}"
+        echo "Computed integrity: ${INTEGRITY}"
+
+        # Origin validation: compare the computed hash against NPG's own published hash,
+        # fetched from the payment-methods-handler integrity endpoint (exposed on APIM in
+        # the ecommerce-for-checkout group). The pipeline holds no NPG credential; the
+        # handler owns the npg-api-key and proxies NPG /build/integrity.
+        echo "Fetching source-of-truth integrity from ${{ parameters.integrity_endpoint }}"
+        SOT_CODE=$(curl -sSL -w "%{http_code}" -o /tmp/sot.json "${{ parameters.integrity_endpoint }}")
+        if [ "${SOT_CODE}" != "200" ]; then
+          echo "##vso[task.logissue type=error]Integrity endpoint call failed with HTTP ${SOT_CODE}"
+          exit 1
+        fi
+
+        SOT_INTEGRITY=$(jq -r '.integrityHash // .integrity // empty' /tmp/sot.json)
+        if [ -z "${SOT_INTEGRITY}" ]; then
+          echo "##vso[task.logissue type=error]Integrity endpoint returned no hash"
+          exit 1
+        fi
+        echo "Source-of-truth integrity: ${SOT_INTEGRITY}"
+
+        # Normalize the optional sha384- prefix on both sides before comparing.
+        if [ "${INTEGRITY#sha384-}" != "${SOT_INTEGRITY#sha384-}" ]; then
+          echo "##vso[task.logissue type=error]Integrity mismatch: computed ${INTEGRITY} vs source-of-truth ${SOT_INTEGRITY}. Not publishing; keeping last-known-good."
+          exit 1
+        fi
+        echo "Integrity verified against NPG source of truth"
+
+        echo "{\"integrityHash\":\"${INTEGRITY}\"}" > /tmp/hfsdk.integrity.json
+
+        echo "Uploading SDK to platform CDN storage (${TARGET_FOLDER}/hfsdk.js)"
+        az storage blob upload \
+          --account-name "${STORAGE_ACCOUNT}" \
+          --account-key "${AZURE_STORAGE_KEY}" \
+          --auth-mode key \
+          --container-name '$web' \
+          --name "${TARGET_FOLDER}/hfsdk.js" \
+          --file /tmp/hfsdk.js \
+          --content-type "application/javascript" \
+          --overwrite
+
+        echo "Uploading integrity JSON to platform CDN storage (${TARGET_FOLDER}/hfsdk.integrity.json)"
+        az storage blob upload \
+          --account-name "${STORAGE_ACCOUNT}" \
+          --account-key "${AZURE_STORAGE_KEY}" \
+          --auth-mode key \
+          --container-name '$web' \
+          --name "${TARGET_FOLDER}/hfsdk.integrity.json" \
+          --file /tmp/hfsdk.integrity.json \
+          --content-type "application/json" \
+          --overwrite
+
+        echo "Purging CDN for /${TARGET_FOLDER}/*"
+        # keep working after the built-in cdn/afd commands are removed from az core.
+        az config set extension.use_dynamic_install=yes_without_prompt --only-show-errors
+        az afd endpoint purge \
+          -g "${{ parameters.cdn_rg }}" \
+          --endpoint-name "${CDN_ENDPOINT}" \
+          --profile-name "${{ parameters.cdn_profile }}" \
+          --content-paths "/${TARGET_FOLDER}/*"
+
+        # Success heartbeat: emit a NpgSdkSyncSuccess customEvent to App Insights, only
+        # for the variant that backs prod consumption (the paging source for the
+        # staleness alert). No heartbeat in the last 3h => the sync has stopped/failing.
+        if [ "${EMIT_HEARTBEAT}" = "true" ]; then
+          echo "Emitting sync-success heartbeat to App Insights"
+          # disable xtrace so the App Insights connection string / instrumentation
+          # key are never echoed to the log
+          set +x
+          # bounded with timeout so a hung ARM call can never stall the pipeline
+          AI_CONN=$(timeout 30 az monitor app-insights component show \
+            --app "${{ parameters.app_insights_name }}" \
+            -g "${{ parameters.app_insights_rg }}" \
+            --query connectionString -o tsv 2>/dev/null || true)
+          if [ -n "${AI_CONN}" ]; then
+            IKEY=$(printf '%s' "${AI_CONN}" | sed -n 's/.*InstrumentationKey=\([^;]*\).*/\1/p')
+            INGEST=$(printf '%s' "${AI_CONN}" | sed -n 's/.*IngestionEndpoint=\([^;]*\).*/\1/p')
+            HEARTBEAT_TIME=$(date -u +%Y-%m-%dT%H:%M:%S.000Z)
+            # payload + response go to unpredictable temp files (mktemp). Keeping the
+            # iKey in the payload file means it never lands in the process args (argv).
+            HB_PAYLOAD=$(mktemp)
+            HB_RESP=$(mktemp)
+            printf '{"name":"Microsoft.ApplicationInsights.Event","time":"%s","iKey":"%s","data":{"baseType":"EventData","baseData":{"ver":2,"name":"NpgSdkSyncSuccess","properties":{"integrity":"%s","folder":"%s"}}}}' \
+              "${HEARTBEAT_TIME}" "${IKEY}" "${INTEGRITY}" "${TARGET_FOLDER}" > "${HB_PAYLOAD}"
+            # -o sends the body to a file (never stdout); -w prints only the HTTP
+            # status; connect/max timeouts guarantee the call cannot hang the job.
+            HB_CODE=$(curl -sS -o "${HB_RESP}" -w '%{http_code}' \
+              --connect-timeout 10 --max-time 30 \
+              -X POST "${INGEST}v2/track" -H 'Content-Type: application/json' \
+              -d @"${HB_PAYLOAD}" || true)
+            # itemsAccepted is the authoritative "did it land" signal - a 200 alone is
+            # not enough (App Insights can 200 with itemsAccepted:0). The v2/track
+            # response never contains the iKey, so these fields are safe to log.
+            HB_ACCEPTED=$(sed -n 's/.*"itemsAccepted":\([0-9][0-9]*\).*/\1/p' "${HB_RESP}")
+            HB_ERRORS=$(sed -n 's/.*\("errors":\[[^]]*\]\).*/\1/p' "${HB_RESP}")
+            rm -f "${HB_PAYLOAD}" "${HB_RESP}"
+            if [ "${HB_ACCEPTED:-0}" -ge 1 ]; then
+              echo "Heartbeat emitted (HTTP ${HB_CODE:-000}, itemsAccepted=${HB_ACCEPTED})"
+            else
+              echo "##vso[task.logissue type=warning]Heartbeat NOT accepted by App Insights (HTTP ${HB_CODE:-000}, itemsAccepted=${HB_ACCEPTED:-0}) ${HB_ERRORS}; sync itself succeeded."
+            fi
+          else
+            echo "##vso[task.logissue type=warning]Could not resolve App Insights connection string; heartbeat skipped (sync itself succeeded)"
+          fi
+        fi
+
+        echo "Sync complete for ${TARGET_FOLDER}"

--- a/.devops/pagopa-npg-sdk-sync-deploy-pipelines.yml
+++ b/.devops/pagopa-npg-sdk-sync-deploy-pipelines.yml
@@ -34,7 +34,7 @@ stages:
           - template: azure-templates/sync-npg-sdk-steps.yml
             parameters:
               npg_origin: 'https://stg-ta.nexigroup.com'
-              integrity_endpoint: 'https://api.dev.platform.pagopa.it/checkout/npg/sdk/v1/integrity'
+              integrity_endpoint: 'https://api.uat.platform.pagopa.it/checkout/npg/sdk/v1/integrity'
               target_folder: 'npg-uat'
               storage_account: '$(PROD_STORAGE_ACCOUNT_NAME)'
               cdn_rg: '$(PROD_RESOURCE_GROUP_NAME)'

--- a/.devops/pagopa-npg-sdk-sync-deploy-pipelines.yml
+++ b/.devops/pagopa-npg-sdk-sync-deploy-pipelines.yml
@@ -1,0 +1,64 @@
+# Azure DevOps pipeline to sync the NPG SDK from Nexi to the platform CDN.
+# Runs hourly. NPG has two real environments (staging and production), so the
+# pipeline publishes two folders on the single platform CDN ($web):
+#   - npg-uat  <- NPG staging (stg-ta.nexigroup.com), verified via the UAT integrity API
+#   - npg-prod <- NPG production (xpay.nexigroup.com), verified via the PROD integrity API
+# For each variant it downloads the SDK, computes its SHA-384, verifies it against
+# NPG's source-of-truth hash (payment-methods-handler integrity endpoint via APIM),
+# and only on a match publishes hfsdk.js + hfsdk.integrity.json into the folder.
+# Storage/CDN/subscription values come from the ADO registration (core project):
+#   $(PROD_STORAGE_ACCOUNT_NAME), $(PROD_PROFILE_CDN_NAME), $(PROD_ENDPOINT_NAME),
+#   $(PROD_RESOURCE_GROUP_NAME), $(PROD_AZURE_SUBSCRIPTION), $(PROD_AZURE_STORAGE_KEY).
+
+trigger: none
+pr: none
+
+schedules:
+  - cron: "0 * * * *"
+    displayName: "Sync NPG SDK hourly"
+    branches:
+      include:
+        - main
+    always: true
+
+pool:
+  vmImage: 'ubuntu-latest'
+
+stages:
+  - stage: Sync_npg_uat
+    dependsOn: []
+    jobs:
+      - job: sync_npg_sdk_uat
+        displayName: 'Sync NPG SDK (staging) -> npg-uat'
+        steps:
+          - template: azure-templates/sync-npg-sdk-steps.yml
+            parameters:
+              npg_origin: 'https://stg-ta.nexigroup.com'
+              integrity_endpoint: 'https://api.uat.platform.pagopa.it/checkout/npg/sdk/v1/integrity'
+              target_folder: 'npg-uat'
+              storage_account: '$(PROD_STORAGE_ACCOUNT_NAME)'
+              cdn_rg: '$(PROD_RESOURCE_GROUP_NAME)'
+              cdn_profile: '$(PROD_PROFILE_CDN_NAME)'
+              cdn_endpoint: '$(PROD_ENDPOINT_NAME)'
+              service_connection: '$(PROD_AZURE_SUBSCRIPTION)'
+              emit_heartbeat: 'false'
+
+  - stage: Sync_npg_prod
+    dependsOn: []
+    jobs:
+      - job: sync_npg_sdk_prod
+        displayName: 'Sync NPG SDK (production) -> npg-prod'
+        steps:
+          - template: azure-templates/sync-npg-sdk-steps.yml
+            parameters:
+              npg_origin: 'https://xpay.nexigroup.com'
+              integrity_endpoint: 'https://api.platform.pagopa.it/checkout/npg/sdk/v1/integrity'
+              target_folder: 'npg-prod'
+              storage_account: '$(PROD_STORAGE_ACCOUNT_NAME)'
+              cdn_rg: '$(PROD_RESOURCE_GROUP_NAME)'
+              cdn_profile: '$(PROD_PROFILE_CDN_NAME)'
+              cdn_endpoint: '$(PROD_ENDPOINT_NAME)'
+              service_connection: '$(PROD_AZURE_SUBSCRIPTION)'
+              emit_heartbeat: 'true'
+              app_insights_name: 'pagopa-p-appinsights'
+              app_insights_rg: 'pagopa-p-monitor-rg'

--- a/.devops/pagopa-npg-sdk-sync-deploy-pipelines.yml
+++ b/.devops/pagopa-npg-sdk-sync-deploy-pipelines.yml
@@ -34,7 +34,7 @@ stages:
           - template: azure-templates/sync-npg-sdk-steps.yml
             parameters:
               npg_origin: 'https://stg-ta.nexigroup.com'
-              integrity_endpoint: 'https://api.uat.platform.pagopa.it/checkout/npg/sdk/v1/integrity'
+              integrity_endpoint: 'https://api.dev.platform.pagopa.it/checkout/npg/sdk/v1/integrity'
               target_folder: 'npg-uat'
               storage_account: '$(PROD_STORAGE_ACCOUNT_NAME)'
               cdn_rg: '$(PROD_RESOURCE_GROUP_NAME)'

--- a/.devops/pagopa-npg-sdk-sync-deploy-pipelines.yml
+++ b/.devops/pagopa-npg-sdk-sync-deploy-pipelines.yml
@@ -1,14 +1,11 @@
-# Azure DevOps pipeline to sync the NPG SDK from Nexi to the platform CDN.
-# Runs hourly. NPG has two real environments (staging and production), so the
-# pipeline publishes two folders on the single platform CDN ($web):
-#   - npg-uat  <- NPG staging (stg-ta.nexigroup.com), verified via the UAT integrity API
-#   - npg-prod <- NPG production (xpay.nexigroup.com), verified via the PROD integrity API
-# For each variant it downloads the SDK, computes its SHA-384, verifies it against
-# NPG's source-of-truth hash (payment-methods-handler integrity endpoint via APIM),
-# and only on a match publishes hfsdk.js + hfsdk.integrity.json into the folder.
-# Storage/CDN/subscription values come from the ADO registration (core project):
-#   $(PROD_STORAGE_ACCOUNT_NAME), $(PROD_PROFILE_CDN_NAME), $(PROD_ENDPOINT_NAME),
-#   $(PROD_RESOURCE_GROUP_NAME), $(PROD_AZURE_SUBSCRIPTION), $(PROD_AZURE_STORAGE_KEY).
+# Hourly sync of the NPG SDK from Nexi to the platform CDN ($web). NPG has two real
+# environments, so two folders are published:
+#   - npg-uat  <- NPG staging (stg-ta.nexigroup.com), verified via UAT /integrity
+#   - npg-prod <- NPG production (xpay.nexigroup.com), verified via PROD /integrity
+# Each variant downloads the SDK, computes its SHA-384, verifies it against NPG's
+# source-of-truth hash (payment-methods-handler /integrity via APIM), and only on a
+# match publishes hfsdk.js + hfsdk.integrity.json. Storage/CDN/subscription vars
+# ($(PROD_*)) come from the ADO core registration.
 
 trigger: none
 pr: none
@@ -29,7 +26,7 @@ stages:
     dependsOn: []
     jobs:
       - job: sync_npg_sdk_uat
-        displayName: 'Sync NPG SDK (staging) -> npg-uat'
+        displayName: 'Sync NPG SDK (staging)'
         steps:
           - template: azure-templates/sync-npg-sdk-steps.yml
             parameters:
@@ -47,7 +44,7 @@ stages:
     dependsOn: []
     jobs:
       - job: sync_npg_sdk_prod
-        displayName: 'Sync NPG SDK (production) -> npg-prod'
+        displayName: 'Sync NPG SDK (production)'
         steps:
           - template: azure-templates/sync-npg-sdk-steps.yml
             parameters:


### PR DESCRIPTION
depends on https://github.com/pagopa/pagopa-infra/pull/3937

Note: I left more comments than usual on the script since this is a new kind of implementation that was never done or documented before, feel free to give feedbacks and reword them/remove them with suggestions

<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->

- add reusable `.devops/azure-templates/sync-npg-sdk-steps.yml`: download the NPG SDK from an origin, compute its SHA-384, verify it against the payment-methods-handler `/integrity` endpoint (via APIM), and only on a match publish `hfsdk.js` + `hfsdk.integrity.json` into a target folder of the platform CDN `$web`, then purge the AFD endpoint; fail-closed on mismatch (keep last-known-good)
- add `.devops/pagopa-npg-sdk-sync-deploy-pipelines.yml`: hourly schedule-only pipeline (`trigger: none`, `pr: none`, cron `0 * * * *`, `always: true`) with two stages, `Sync_npg_uat` (NPG staging -> `npg-uat`) and `Sync_npg_prod` (NPG production -> `npg-prod`)
- read the storage key from the `AZURE_STORAGE_KEY` env var (secret pipeline variable), never a template parameter; source storage/CDN/subscription from the `core` ADO registration variables
- emit a `NpgSdkSyncSuccess` App Insights heartbeat only from the prod variant, as the paging source for the staleness alert

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

[PIDM-2152](https://pagopa.atlassian.net/browse/PIDM-2152). Centralize self-hosting of the third-party NPG hosted-fields SDK on the platform CDN with SRI, so the frontends that use it (checkout, wallet-fe, ecommerce-fe) load a pagoPA-controlled copy verified against NPG's own hash. This is the supply side (Phase 1): the pipeline publishes the folders but no frontend consumes them yet, giving SAQ-A supply-chain integrity without risking payment availability (fail-closed on publish, last-known-good on serve).

### Type of changes

- [x] Add new pipeline
- [ ] Update pipeline configuration
- [ ] Remove pipeline

### :warning: If it's new pipeline with code review have you added pagopa-github-bot -> Role: admin?

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
- DEV sync test (repointing the UAT endpoint temporarily) -> https://dev.azure.com/pagopaspa/pagoPA-projects/_build/results?buildId=282864&view=logs&j=ff1530e1-21d7-50bf-c963-925a32c64d19&t=5b2d9895-5627-5df5-00d3-b68c59d11f3c<br>
```
% curl -sS -o /dev/null -w "%{http_code}\n" https://assets.cdn.platform.pagopa.it/npg-uat/hfsdk.js
200
```
```
% curl -sS https://assets.cdn.platform.pagopa.it/npg-uat/hfsdk.integrity.json
{"integrityHash":"sha384-x5lbMY...."}
```

Schedule-only pipeline (no CI/PR trigger). Not yet run: it needs this YAML on `main` plus the `core` ADO registration ([pagopa-azure-devops#477](https://github.com/pagopa/pagopa-azure-devops/pull/477)) applied to create the build definition, and the target env's `/integrity` exposed on APIM ([pagopa-infra#3937](https://github.com/pagopa/pagopa-infra/pull/3937)) with the real `npg-api-key` set, before a green run is expected. YAML validated by the ADO linter at registration.

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->


[PIDM-2152]: https://pagopa.atlassian.net/browse/PIDM-2152?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ